### PR TITLE
fix: updated & renamed hangman.sh

### DIFF
--- a/hangman.sh
+++ b/hangman.sh
@@ -1,1 +1,2 @@
+#!/bin/bash
 python3 hangman.py


### PR DESCRIPTION
This fixes: #3

- I renamed the file as I assumed it was a typo `hangmanl.sh` -> `hangman.sh`
- I added executable rights to the file
- I added `#!/bin/bash` to `hangman.sh`. This is called a **shebang**, it is used to specify what interpreter should be used when executing the script.